### PR TITLE
gstreamer reports video/quicktime only but supports video/mp4

### DIFF
--- a/src/upnp_connmgr.c
+++ b/src/upnp_connmgr.c
@@ -244,6 +244,9 @@ void register_mime_type(const char *mime_type) {
 	  register_mime_type_internal("audio/m4a");
 	  register_mime_type_internal("audio/mp4");
 	}
+	if (strcmp("video/quicktime", mime_type) == 0) {
+	  register_mime_type_internal("video/mp4");
+	}
 }
 
 static mime_type_filters_t connmgr_parse_mime_filter_string(const char* filter_string)


### PR DESCRIPTION
gstreamer reports video/quicktime only but supports video/mp4.
Let clients which filter by mime type but not let turning off the filter play mp4 videos.